### PR TITLE
Add feature to disable terminal tab.

### DIFF
--- a/dashboard/gateway/routes/dashboard.js
+++ b/dashboard/gateway/routes/dashboard.js
@@ -3,6 +3,7 @@ var path = require('path');
 var fs = require('fs');
 
 var enable_dashboard = process.env.ENABLE_DASHBOARD;
+var enable_terminal = process.env.ENABLE_TERMINAL || 'true';
 
 module.exports = function(app, prefix) {
     var router = express();
@@ -13,7 +14,11 @@ module.exports = function(app, prefix) {
 
     router.locals.project_namespace = process.env.PROJECT_NAMESPACE;
 
-    router.locals.terminal_tab = process.env.TERMINAL_TAB;
+    if( enable_terminal == 'true' ) {
+        router.locals.terminal_tab = process.env.TERMINAL_TAB;
+    } else {
+        router.locals.terminal_tab = 'disabled'
+    }
 
     router.locals.console_url = process.env.CONSOLE_URL;
     router.locals.restart_url = process.env.RESTART_URL;

--- a/dashboard/gateway/views/dashboard.pug
+++ b/dashboard/gateway/views/dashboard.pug
@@ -326,7 +326,7 @@ html
 
         div.split.split-horizontal.pane-content#workarea-div
             ul.nav.nav-pills.mb-1#workarea-nav(role="tablist")
-                if terminal_tab != 'disable'
+                if terminal_tab != 'disabled'
                     li.nav-item
                         a.nav-link.active#terminals-tab(data-toggle="tab" href="#terminals-pane" role="tab" aria-controls="terminals-pane" aria-selected=true) Terminal
 
@@ -350,7 +350,7 @@ html
 
                             li.dropdown-item
                                 a(role="menuitem" onclick=`reload_workshop();`) Reload Workshop
-                            if terminal_tab != 'disable'
+                            if terminal_tab != 'disabled'
                                 li.dropdown-item
                                     a(role="menuitem" onclick=`reload_terminal();`) Reload Terminal
                             if console_url
@@ -361,7 +361,7 @@ html
 
                             li.dropdown-item
                                 a(role="menuitem" onclick=`window.open("../workshop");`) Open Workshop
-                            if terminal_tab != 'disable'
+                            if terminal_tab != 'disabled'
                                 li.dropdown-item
                                     a(role="menuitem" onclick=`window.open("../terminal/session/"+generate_terminal_session_id());`) Open Terminal
                             if console_url
@@ -375,7 +375,7 @@ html
                                 li.dropdown-item
                                     a(role="menuitem", data-toggle="modal", data-target="#restart-confirmation") Restart Session
 
-            if terminal_tab != 'disable'
+            if terminal_tab != 'disabled'
                 div.tab-content
                     div.tab-pane.fade.show.active#terminals-pane(role="tabpanel" aria-labelledby="terminals-tab")
                         div.split.iframe-div#terminal1-div

--- a/dashboard/gateway/views/dashboard.pug
+++ b/dashboard/gateway/views/dashboard.pug
@@ -326,8 +326,9 @@ html
 
         div.split.split-horizontal.pane-content#workarea-div
             ul.nav.nav-pills.mb-1#workarea-nav(role="tablist")
-                li.nav-item
-                    a.nav-link.active#terminals-tab(data-toggle="tab" href="#terminals-pane" role="tab" aria-controls="terminals-pane" aria-selected=true) Terminal
+                if terminal_tab != 'disable'
+                    li.nav-item
+                        a.nav-link.active#terminals-tab(data-toggle="tab" href="#terminals-pane" role="tab" aria-controls="terminals-pane" aria-selected=true) Terminal
 
                 if console_url
                     li.nav-item
@@ -349,8 +350,9 @@ html
 
                             li.dropdown-item
                                 a(role="menuitem" onclick=`reload_workshop();`) Reload Workshop
-                            li.dropdown-item
-                                a(role="menuitem" onclick=`reload_terminal();`) Reload Terminal
+                            if terminal_tab != 'disable'
+                                li.dropdown-item
+                                    a(role="menuitem" onclick=`reload_terminal();`) Reload Terminal
                             if console_url
                                 li.dropdown-item
                                     a(role="menuitem" onclick=`reload_console();`) Reload Console
@@ -359,8 +361,9 @@ html
 
                             li.dropdown-item
                                 a(role="menuitem" onclick=`window.open("../workshop");`) Open Workshop
-                            li.dropdown-item
-                                a(role="menuitem" onclick=`window.open("../terminal/session/"+generate_terminal_session_id());`) Open Terminal
+                            if terminal_tab != 'disable'
+                                li.dropdown-item
+                                    a(role="menuitem" onclick=`window.open("../terminal/session/"+generate_terminal_session_id());`) Open Terminal
                             if console_url
                                 li.dropdown-item
                                     a(role="menuitem" onclick=`window.open("../console");`) Open Console
@@ -372,26 +375,27 @@ html
                                 li.dropdown-item
                                     a(role="menuitem", data-toggle="modal", data-target="#restart-confirmation") Restart Session
 
-            div.tab-content
-                div.tab-pane.fade.show.active#terminals-pane(role="tabpanel" aria-labelledby="terminals-tab")
-                    div.split.iframe-div#terminal1-div
-                        iframe#terminal1-iframe(src="../terminal/session/1")
-                    if terminal_tab == 'split'
-                        div.split.iframe-div#terminal2-div
-                            iframe#terminal2-iframe(src="../terminal/session/2")
-                    if terminal_tab == 'split/2'
-                        div.split.iframe-div#terminal2-div
-                            iframe#terminal2-iframe(src="../terminal/session/2")
-                        div.split.iframe-div#terminal3-div
-                            iframe#terminal3-iframe(src="../terminal/session/3")
+            if terminal_tab != 'disable'
+                div.tab-content
+                    div.tab-pane.fade.show.active#terminals-pane(role="tabpanel" aria-labelledby="terminals-tab")
+                        div.split.iframe-div#terminal1-div
+                            iframe#terminal1-iframe(src="../terminal/session/1")
+                        if terminal_tab == 'split'
+                            div.split.iframe-div#terminal2-div
+                                iframe#terminal2-iframe(src="../terminal/session/2")
+                        if terminal_tab == 'split/2'
+                            div.split.iframe-div#terminal2-div
+                                iframe#terminal2-iframe(src="../terminal/session/2")
+                            div.split.iframe-div#terminal3-div
+                                iframe#terminal3-iframe(src="../terminal/session/3")
 
-                if console_url
-                    div.tab-pane.fade.show.iframe-div#console-pane(role="tabpanel" aria-labelledby="console-tab")
-                        iframe#console-iframe(src="../console")
+                    if console_url
+                        div.tab-pane.fade.show.iframe-div#console-pane(role="tabpanel" aria-labelledby="console-tab")
+                            iframe#console-iframe(src="../console")
 
-                if with_slides
-                    div.tab-pane.fade.show.iframe-div#slides-pane(role="tabpanel" aria-labelledby="slides-tab")
-                        iframe#slides-iframe(src="../slides/index.html")
+                    if with_slides
+                        div.tab-pane.fade.show.iframe-div#slides-pane(role="tabpanel" aria-labelledby="slides-tab")
+                            iframe#slides-iframe(src="../slides/index.html")
 
         script.
             require(['split'], function(split) {

--- a/dashboard/gateway/views/dashboard.pug
+++ b/dashboard/gateway/views/dashboard.pug
@@ -375,8 +375,8 @@ html
                                 li.dropdown-item
                                     a(role="menuitem", data-toggle="modal", data-target="#restart-confirmation") Restart Session
 
-            if terminal_tab != 'disabled'
-                div.tab-content
+            div.tab-content
+                if terminal_tab != 'disabled'
                     div.tab-pane.fade.show.active#terminals-pane(role="tabpanel" aria-labelledby="terminals-tab")
                         div.split.iframe-div#terminal1-div
                             iframe#terminal1-iframe(src="../terminal/session/1")
@@ -389,13 +389,13 @@ html
                             div.split.iframe-div#terminal3-div
                                 iframe#terminal3-iframe(src="../terminal/session/3")
 
-                    if console_url
-                        div.tab-pane.fade.show.iframe-div#console-pane(role="tabpanel" aria-labelledby="console-tab")
-                            iframe#console-iframe(src="../console")
+                if console_url
+                    div.tab-pane.fade.show.iframe-div#console-pane(role="tabpanel" aria-labelledby="console-tab")
+                        iframe#console-iframe(src="../console")
 
-                    if with_slides
-                        div.tab-pane.fade.show.iframe-div#slides-pane(role="tabpanel" aria-labelledby="slides-tab")
-                            iframe#slides-iframe(src="../slides/index.html")
+                if with_slides
+                    div.tab-pane.fade.show.iframe-div#slides-pane(role="tabpanel" aria-labelledby="slides-tab")
+                        iframe#slides-iframe(src="../slides/index.html")
 
         script.
             require(['split'], function(split) {
@@ -450,3 +450,5 @@ html
                 var style = '<style>a { pointer-events: none }</style>';
                 $(this).contents().find('head').append(style);
             });
+
+            $($('#workarea-nav>li>a')[0]).trigger("click");


### PR DESCRIPTION
This commit adds the ability to set TERMINAL_TAB=disable in order to
disable the terminal tab for workshops that do not require it.

resolves #49